### PR TITLE
Model 2 Child Growth Risk Factors Implementation

### DIFF
--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -9,6 +9,17 @@ components:
             - SIS('diarrheal_diseases')
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
+        risks:
+            - Risk('risk_factor.child_wasting')
+            - RiskEffect('risk_factor.child_wasting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_wasting', 'cause.lower_respiratory_infections.incidence_rate')
+
+            - Risk('risk_factor.child_stunting')
+            - RiskEffect('risk_factor.child_stunting', 'cause.diarrheal_diseases.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
+            - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
+
     vivarium_gates_child_iv_iron:
         components:
             - DisabilityObserver()


### PR DESCRIPTION
## Model 2 Child Growth Risk Factors Implementation

### Description
- *Category*: implementation
- *JIRA issue*: [MIC-2956](https://jira.ihme.washington.edu/browse/MIC-2956) 
- *Research reference*: [Child Growth Risk Factors](https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/child_model/concept_model.html#risk-exposure-models)

### Verification and Testing
Checked stunting and wasting exposures were present in the correct proportions across the entire population in an interactive sim for South Asia.
Ran enough time steps to get a decent number of incident cases of our three causes and checked that proportions of incident cases for each exposure category accorded roughly with the relative risk data (very roughly given the small number of cases) for South Asia.  
Successfully ran very-few-time-steps runs for South Asia and Sub-Saharan Africa.
