### PR TITLE
Feature/lbwsg observers

### DIFF
--- a/src/vivarium_gates_child_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_child_iv_iron/components/__init__.py
@@ -1,1 +1,1 @@
-from vivarium_gates_child_iv_iron.components.observers import ResultsStratifier
+from vivarium_gates_child_iv_iron.components.observers import BirthObserver, ResultsStratifier

--- a/src/vivarium_gates_child_iv_iron/components/observers.py
+++ b/src/vivarium_gates_child_iv_iron/components/observers.py
@@ -74,7 +74,7 @@ class BirthObserver:
 
     birth_weight_column_name = "birth_weight_exposure"
     gestational_age_column_name = "gestational_age_exposure"
-    columns_required = ["age", birth_weight_column_name, gestational_age_column_name]
+    columns_required = ["entrance_time", birth_weight_column_name, gestational_age_column_name]
 
     low_birth_weight_limit = 2500 # grams
 
@@ -116,7 +116,7 @@ class BirthObserver:
         return builder.population.get_view(self.columns_required)
 
     def _register_collect_metrics_listener(self, builder: Builder) -> None:
-        builder.event.register_listener("time_step", self.on_collect_metrics)
+        builder.event.register_listener("collect_metrics", self.on_collect_metrics)
 
     def _register_metrics_modifier(self, builder: Builder) -> None:
         builder.value.register_value_modifier(
@@ -131,8 +131,7 @@ class BirthObserver:
 
     def on_collect_metrics(self, event: Event) -> None:
         pop = self.population_view.get(event.index)
-        step_size = to_years(event.step_size)
-        pop_born = pop[pop['age'] <= step_size]
+        pop_born = pop[pop['entrance_time'] == event.time - event.step_size]
 
         groups = self.stratifier.group(
             pop_born.index, self.config.include, self.config.exclude

--- a/src/vivarium_gates_child_iv_iron/components/observers.py
+++ b/src/vivarium_gates_child_iv_iron/components/observers.py
@@ -64,7 +64,7 @@ class BirthObserver:
     configuration_defaults = {
         "observers": {
             "birth": {
-                "exclude": [],
+                "exclude": ["age"],
                 "include": [],
             }
         }

--- a/src/vivarium_gates_child_iv_iron/components/observers.py
+++ b/src/vivarium_gates_child_iv_iron/components/observers.py
@@ -51,3 +51,102 @@ class ResultsStratifier(ResultsStratifier_):
             "cat2": data_keys.CGFCategories.MODERATE.value,
             "cat1": data_keys.CGFCategories.SEVERE.value,
         }[row.squeeze()]
+
+
+class BirthObserver:
+
+    configuration_defaults = {
+        "observers": {
+            "birth": {
+                "exclude": [],
+                "include": [],
+            }
+        }
+    }
+
+    metrics_pipeline_name = "metrics"
+
+    # todo name columns
+    birth_weight_column_name = ''
+    gestational_age_column_name = ''
+
+    def __repr__(self):
+        return "BirthObserver()"
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self):
+        return "birth_observer"
+
+    #################
+    # Setup methods #
+    #################
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder) -> None:
+        self.config = self._get_stratification_configuration(builder)
+        self.stratifier = self._get_stratifier(builder)
+        self.population_view = self._get_population_view(builder)
+
+        self.counts = Counter()
+
+        self._register_collect_metrics_listener(builder)
+        self._register_metrics_modifier(builder)
+
+    # noinspection PyMethodMayBeStatic
+    def _get_stratification_configuration(self, builder: Builder) -> ConfigTree:
+        return builder.configuration.observers.birth
+
+    # noinspection PyMethodMayBeStatic
+    def _get_stratifier(self, builder: Builder) -> ResultsStratifier:
+        return builder.components.get_component(ResultsStratifier.name)
+
+
+    def _get_population_view(self, builder: Builder) -> PopulationView:
+        # todo get with correct columns
+
+    def _register_collect_metrics_listener(self, builder: Builder) -> None:
+        builder.event.register_listener("time_step", self.on_collect_metrics)
+
+    def _register_metrics_modifier(self, builder: Builder) -> None:
+        builder.value.register_value_modifier(
+            self.metrics_pipeline_name,
+            modifier=self.metrics,
+            requires_columns=["age", "exit_time", "alive"],
+        )
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_collect_metrics(self, event: Event) -> None:
+        pop = self.population_view.get(event.index)
+        # todo make sure this works with initial initialization
+        pop_born = pop[pop["entrance_time"] == event.time]
+
+        groups = self.stratifier.group(
+            pop_born.index, self.config.include, self.config.exclude
+        )
+        for label, group_mask in groups:
+            pop_born_in_group = pop_born[group_mask]
+            low_birth_weight_mask = pop_born_in_group[self.birth_weight_column_name] < birth_weight_limit
+            new_observations = {
+                f"live_births_{label}": pop_born_in_group.index.size,
+                f"birth_weight_sum_{label}": pop_born_in_group[self.birth_weight_column_name].sum(),
+                f"gestational_age_sum_{label}":
+                    pop_born_in_group[self.gestational_age_column_name].sum(),
+                f'low_weight_births_{label}': low_birth_weight_mask.sum()
+            }
+            self.counts.update(new_observations)
+
+    ##################################
+    # Pipeline sources and modifiers #
+    ##################################
+
+    def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
+        metrics.update(self.counts)
+
+        return metrics

--- a/src/vivarium_gates_child_iv_iron/constants/metadata.py
+++ b/src/vivarium_gates_child_iv_iron/constants/metadata.py
@@ -20,7 +20,8 @@ YEAR_DURATION: float = 365.25
 LOCATIONS = [
     "Sub-Saharan Africa",
     "South Asia",
-    "LMICs"
+    "LMICs",
+    "Ethiopia",
 ]
 
 ARTIFACT_INDEX_COLUMNS = [

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -82,7 +82,3 @@ configuration:
             - "year"
             - "sex"
             - "age"
-        birth:
-            by_age: False
-            by_sex: True
-            by_year: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -81,3 +81,7 @@ configuration:
             - "year"
             - "sex"
             - "age"
+        birth:
+            by_age: False
+            by_sex: True
+            by_year: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -82,3 +82,7 @@ configuration:
             - "year"
             - "sex"
             - "age"
+        birth:
+            by_age: False
+            by_sex: True
+            by_year: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -39,6 +39,7 @@ components:
     vivarium_gates_child_iv_iron:
         components:
             - ResultsStratifier()
+            - BirthObserver()
 
 configuration:
     input_data:

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -40,6 +40,7 @@ components:
     vivarium_gates_child_iv_iron:
         components:
             - ResultsStratifier()
+            - BirthObserver()
 
 configuration:
     input_data:


### PR DESCRIPTION
## Feature/LBWSG Observers

### Added LBWSG Observers to capture birth metrics of simulants.
- *Category*: Observers
- *JIRA issue*: [MIC-2962](https://jira.ihme.washington.edu/browse/MIC-2962)
- *Research reference*: https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/child_model/concept_model.html#simulation-output-table

Added observers for LBWSG to capture birth metrics.  Added Ethiopia to metadata to test implementation of PAF data since that is the current PAF data we are using for LBWSG.  

### Verification and Testing
Successfully ran a  simulation and saw the 4 desired outputs being captured.
