### PR TITLE
Feature/Line List Fertility

### DIFF
--- a/src/vivarium_gates_child_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_child_iv_iron/components/__init__.py
@@ -1,1 +1,4 @@
+from vivarium_gates_child_iv_iron.components.fertility import FertilityLineList
+from vivarium_gates_child_iv_iron.components.lbwsg import LBWSGLineList
 from vivarium_gates_child_iv_iron.components.observers import BirthObserver, ResultsStratifier
+from vivarium_gates_child_iv_iron.components.population import PopulationLineList

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -25,11 +25,7 @@ class FertilityLineList:
     line list data.  Simulants will be registered to the state table on the time steps in which their birth takes place.
     """
 
-    configuration_defaults = {
-        "fertility": {
-            "fertility_input_data_path": ""
-        }
-    }
+    configuration_defaults = {}
 
     def __repr__(self):
         return "FertilityLineList()"
@@ -40,9 +36,8 @@ class FertilityLineList:
 
     def setup(self, builder):
         self.clock = builder.time.clock()
+        self.fertility_data_directory = builder.configuration.input_data.fertility_input_data_path
         self.birth_records = self._get_birth_records()
-        self.fertility_data_directory = builder.configuration.fertility.input_data_path
-        breakpoint()
         self.randomness = builder.randomness
         self.simulant_creator = builder.population.get_simulant_creator()
 
@@ -53,7 +48,7 @@ class FertilityLineList:
         Method to load existing fertility data to use as birth records.
         """
         fertility_data_dir = self.fertility_data_directory
-        file_path = glob.glob(fertility_data_dir + 'south_asia*.hdf')[0]
+        file_path = glob.glob(fertility_data_dir + '*.hdf')[0]
         # todo: fix path names to incorporate what draw and seed to use
         birth_records = pd.read_hdf(file_path)
 
@@ -72,7 +67,7 @@ class FertilityLineList:
             birth_records['birth_date'] > self.clock() - event.step_size)
         born_previous_step = birth_records[born_previous_step_mask]
         simulants_to_add = len(born_previous_step)
-
+        breakpoint()
         if simulants_to_add > 0:
             self.simulant_creator(
                 simulants_to_add,

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
+from vivarium.framework.event import Event
 from vivarium_public_health import utilities
 from vivarium_public_health.population.data_transformations import (
     get_live_births_per_year,
@@ -42,7 +43,7 @@ class FertilityLineList:
         self.fertility_data_directory = builder.configuration.input_data.fertility_input_data_path
         self.draw = builder.configuration.input_data.input_draw_number
         self.seed = builder.configuration.randomness.random_seed
-        self.intervention = builder.configuration.intervention.scenario
+        self.scenario = builder.configuration.intervention.scenario
         self.birth_records = self._get_birth_records()
 
         builder.event.register_listener("time_step", self.on_time_step)
@@ -52,12 +53,12 @@ class FertilityLineList:
         Method to load existing fertility data to use as birth records.
         """
         fertility_data_dir = self.fertility_data_directory
-        file_path = fertility_data_dir + f'scenario_{self.intervention}_draw_{self.draw}_seed_{self.seed}.hdf'
+        file_path = fertility_data_dir + f'scenario_{self.scenario}_draw_{self.draw}_seed_{self.seed}.hdf'
         birth_records = pd.read_hdf(file_path)
 
         return birth_records
 
-    def on_time_step(self, event):
+    def on_time_step(self, event: Event) -> None:
         """Adds new simulants every time step determined by a simulant's birth date in the line list data.
         Parameters
         ----------

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -36,10 +36,15 @@ class FertilityLineList:
 
     def setup(self, builder):
         self.clock = builder.time.clock()
-        self.fertility_data_directory = builder.configuration.input_data.fertility_input_data_path
-        self.birth_records = self._get_birth_records()
         self.randomness = builder.randomness
         self.simulant_creator = builder.population.get_simulant_creator()
+
+        # Requirements for input data
+        self.fertility_data_directory = builder.configuration.input_data.fertility_input_data_path
+        self.draw = builder.configuration.input_data.input_draw_number
+        self.seed = builder.configuration.randomness.random_seed
+        self.intervention = builder.configuration.intervention.scenario
+        self.birth_records = self._get_birth_records()
 
         builder.event.register_listener("time_step", self.on_time_step)
 
@@ -48,8 +53,7 @@ class FertilityLineList:
         Method to load existing fertility data to use as birth records.
         """
         fertility_data_dir = self.fertility_data_directory
-        file_path = glob.glob(fertility_data_dir + '*.hdf')[0]
-        # todo: fix path names to incorporate what draw and seed to use
+        file_path = fertility_data_dir + f'scenario_{self.intervention}_draw_{self.draw}_seed_{self.seed}.hdf'
         birth_records = pd.read_hdf(file_path)
 
         return birth_records

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -66,10 +66,10 @@ class FertilityLineList:
             The event that triggered the function call.
         """
         birth_records = self.birth_records
+        # todo: make sure this is behaving as expected - simulants born during previous time step i.e. they are now new births for current step
         born_previous_step_mask = (birth_records['birth_date'] < self.clock()) & (
             birth_records['birth_date'] > self.clock() - event.step_size)
         born_previous_step = birth_records[born_previous_step_mask]
-        born_previous_step_idx = born_previous_step.index
         simulants_to_add = len(born_previous_step)
 
         if simulants_to_add > 0:
@@ -79,6 +79,6 @@ class FertilityLineList:
                     "age_start": 0,
                     "age_end": 0,
                     "sim_state": "time_step",
-                    "new_births": born_previous_step_idx
+                    "new_births": born_previous_step
                 },
             )

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -67,7 +67,7 @@ class FertilityLineList:
             birth_records['birth_date'] > self.clock() - event.step_size)
         born_previous_step = birth_records[born_previous_step_mask]
         simulants_to_add = len(born_previous_step)
-        breakpoint()
+
         if simulants_to_add > 0:
             self.simulant_creator(
                 simulants_to_add,

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -7,7 +7,6 @@ Fertility module to create simulants from existing data
 
 """
 import numpy as np
-import glob
 import pandas as pd
 from pathlib import Path
 

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -41,7 +41,8 @@ class FertilityLineList:
     def setup(self, builder):
         self.clock = builder.time.clock()
         self.birth_records = self._get_birth_records()
-        self.fertility_data_directory = builder.fertility.fertility_input_data_path
+        self.fertility_data_directory = builder.configuration.fertility.input_data_path
+        breakpoint()
         self.randomness = builder.randomness
         self.simulant_creator = builder.population.get_simulant_creator()
 

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -65,7 +65,6 @@ class FertilityLineList:
             The event that triggered the function call.
         """
         birth_records = self.birth_records
-        # todo: make sure this is behaving as expected - simulants born during previous time step i.e. they are now new births for current step
         born_previous_step_mask = (birth_records['birth_date'] < self.clock()) & (
             birth_records['birth_date'] > self.clock() - event.step_size)
         born_previous_step = birth_records[born_previous_step_mask]

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -1,0 +1,65 @@
+"""
+================
+Fertility Models
+================
+
+Fertility module to create simulants from existing data
+
+"""
+import numpy as np
+import pandas as pd
+
+from vivarium_public_health import utilities
+from vivarium_public_health.population.data_transformations import (
+    get_live_births_per_year,
+)
+
+PREGNANCY_DURATION = pd.Timedelta(days=9 * utilities.DAYS_PER_MONTH)
+
+
+class FertilityFromOutputs:
+    """
+    This class will determine what simulants need to be added to the state table based on their birth data from existing
+    output data.  Simulants will be registered to the state table on the time steps in which their birth takes place.
+    """
+
+    configuration_defaults = {
+        "fertility": {
+            # todo: would this be a good place to flag whether we are using dummy data or real output data?
+        }
+    }
+
+    def __repr__(self):
+        return "FertilityFromOutputs()"
+
+    @property
+    def name(self):
+        return "output_data_fertility"
+
+    def setup(self, builder):
+        self.clock = builder.time.clock()
+        self.randomness = builder.randomness
+        self.simulant_creator = builder.population.get_simulant_creator()
+
+        builder.event.register_listener("time_step", self.on_time_step)
+
+    def on_time_step(self, event):
+        """Adds new simulants every time step determined by a simulant's birth date in the output data.
+        Parameters
+        ----------
+        event
+            The event that triggered the function call.
+        """
+        
+        simulants_to_add = ()
+
+        if simulants_to_add > 0:
+            self.simulant_creator(
+                simulants_to_add,
+                population_configuration={
+                    "age_start": 0,
+                    "age_end": 0,
+                    "sim_state": "time_step",
+                },
+            )
+

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -31,7 +31,6 @@ class FertilityFromOutputs:
         }
     }
 
-    columns_created = ["age", "sex", "alive", "entrance_time", "exit_time"] # not sure if we need location?
     def __repr__(self):
         return "FertilityFromOutputs()"
 
@@ -41,24 +40,23 @@ class FertilityFromOutputs:
 
     def setup(self, builder):
         self.clock = builder.time.clock()
+        self.birth_records = self._get_birth_records()
         self.fertility_data_directory = builder.fertility.fertility_input_data_path
         self.randomness = builder.randomness
         self.simulant_creator = builder.population.get_simulant_creator()
 
-        builder.population.initializes_simulants(
-            self.on_initialize_simulants, creates_columns=self.columns_created
-        )
         builder.event.register_listener("time_step", self.on_time_step)
 
-    def on_initialize_simulants(self) -> None:
+    def _get_birth_records(self) -> pd.DataFrame:
         """
         Method to load existing fertility data to use as birth records.
         """
-#        fertility_data_dir = self.fertility_data_directory
-        fertility_data_dir = "/home/albrja/scratch/data/iv_iron_child/"
+        fertility_data_dir = self.fertility_data_directory
         file_path = glob.glob(fertility_data_dir + 'south_asia*.hdf')[0]
         # todo: fix path names to incorporate what draw and seed to use
-        self.birth_records = pd.read_hdf(file_path)
+        birth_records = pd.read_hdf(file_path)
+
+        return birth_records
 
     def on_time_step(self, event):
         """Adds new simulants every time step determined by a simulant's birth date in the output data.
@@ -68,18 +66,19 @@ class FertilityFromOutputs:
             The event that triggered the function call.
         """
         birth_records = self.birth_records
-        born_previous_step_idx = (birth_records['birth_date'] < self.clock()) & (
+        born_previous_step_mask = (birth_records['birth_date'] < self.clock()) & (
             birth_records['birth_date'] > self.clock() - event.step_size)
-        simulants_to_add = birth_records[born_previous_step_idx]
+        born_previous_step = birth_records[born_previous_step_mask]
+        born_previous_step_idx = born_previous_step.index
+        simulants_to_add = len(born_previous_step)
 
-        # todo: update pop config with new columns
-        if len(simulants_to_add) > 0:
+        if simulants_to_add > 0:
             self.simulant_creator(
                 simulants_to_add,
                 population_configuration={
                     "age_start": 0,
                     "age_end": 0,
                     "sim_state": "time_step",
+                    "new_births": born_previous_step_idx
                 },
             )
-

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -7,7 +7,9 @@ Fertility module to create simulants from existing data
 
 """
 import numpy as np
+import glob
 import pandas as pd
+from pathlib import Path
 
 from vivarium_public_health import utilities
 from vivarium_public_health.population.data_transformations import (
@@ -25,10 +27,11 @@ class FertilityFromOutputs:
 
     configuration_defaults = {
         "fertility": {
-            # todo: would this be a good place to flag whether we are using dummy data or real output data?
+            "fertility_input_data_path": ""
         }
     }
 
+    columns_created = ["age", "sex", "alive", "entrance_time", "exit_time"] # not sure if we need location?
     def __repr__(self):
         return "FertilityFromOutputs()"
 
@@ -38,10 +41,24 @@ class FertilityFromOutputs:
 
     def setup(self, builder):
         self.clock = builder.time.clock()
+        self.fertility_data_directory = builder.fertility.fertility_input_data_path
         self.randomness = builder.randomness
         self.simulant_creator = builder.population.get_simulant_creator()
 
+        builder.population.initializes_simulants(
+            self.on_initialize_simulants, creates_columns=self.columns_created
+        )
         builder.event.register_listener("time_step", self.on_time_step)
+
+    def on_initialize_simulants(self) -> None:
+        """
+        Method to load existing fertility data to use as birth records.
+        """
+#        fertility_data_dir = self.fertility_data_directory
+        fertility_data_dir = "/home/albrja/scratch/data/iv_iron_child/"
+        file_path = glob.glob(fertility_data_dir + 'south_asia*.hdf')[0]
+        # todo: fix path names to incorporate what draw and seed to use
+        self.birth_records = pd.read_hdf(file_path)
 
     def on_time_step(self, event):
         """Adds new simulants every time step determined by a simulant's birth date in the output data.
@@ -50,10 +67,13 @@ class FertilityFromOutputs:
         event
             The event that triggered the function call.
         """
-        
-        simulants_to_add = ()
+        birth_records = self.birth_records
+        born_previous_step_idx = (birth_records['birth_date'] < self.clock()) & (
+            birth_records['birth_date'] > self.clock() - event.step_size)
+        simulants_to_add = birth_records[born_previous_step_idx]
 
-        if simulants_to_add > 0:
+        # todo: update pop config with new columns
+        if len(simulants_to_add) > 0:
             self.simulant_creator(
                 simulants_to_add,
                 population_configuration={

--- a/src/vivarium_gates_child_iv_iron/components/fertility.py
+++ b/src/vivarium_gates_child_iv_iron/components/fertility.py
@@ -19,10 +19,10 @@ from vivarium_public_health.population.data_transformations import (
 PREGNANCY_DURATION = pd.Timedelta(days=9 * utilities.DAYS_PER_MONTH)
 
 
-class FertilityFromOutputs:
+class FertilityLineList:
     """
     This class will determine what simulants need to be added to the state table based on their birth data from existing
-    output data.  Simulants will be registered to the state table on the time steps in which their birth takes place.
+    line list data.  Simulants will be registered to the state table on the time steps in which their birth takes place.
     """
 
     configuration_defaults = {
@@ -32,11 +32,11 @@ class FertilityFromOutputs:
     }
 
     def __repr__(self):
-        return "FertilityFromOutputs()"
+        return "FertilityLineList()"
 
     @property
     def name(self):
-        return "output_data_fertility"
+        return "line_list_fertility"
 
     def setup(self, builder):
         self.clock = builder.time.clock()
@@ -59,7 +59,7 @@ class FertilityFromOutputs:
         return birth_records
 
     def on_time_step(self, event):
-        """Adds new simulants every time step determined by a simulant's birth date in the output data.
+        """Adds new simulants every time step determined by a simulant's birth date in the line list data.
         Parameters
         ----------
         event

--- a/src/vivarium_gates_child_iv_iron/components/lbwsg.py
+++ b/src/vivarium_gates_child_iv_iron/components/lbwsg.py
@@ -1,0 +1,34 @@
+"""
+====================================
+Low Birth Weight and Short Gestation
+====================================
+
+This is a module to subclass the LBWSG component in Vivrium Public Health to use its functionality but to do so on
+simulants who are initialized from line list data.
+
+"""
+import pandas as pd
+
+from vivarium.framework.engine import Builder
+from vivarium.framework.population import SimulantData
+from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import LBWSGRisk
+
+
+class LBWSGLineList(LBWSGRisk):
+    """
+    Component to initialize low birthweight and short gestation data for simulants based on existing line list data.
+    """
+    def __init__(self):
+        super().__init__()
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: Builder):
+        super().setup(builder)
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        new_births = pop_data.user_data["new_births"]
+        new_births = new_births.rename(columns={"birth_weight": "birth_weight_exposure",
+                                                "gestational_age": "gestational_age_exposure"
+                                                }
+                                       )
+        self.population_view.update(new_births)

--- a/src/vivarium_gates_child_iv_iron/components/lbwsg.py
+++ b/src/vivarium_gates_child_iv_iron/components/lbwsg.py
@@ -37,14 +37,13 @@ class LBWSGLineList(LBWSGRisk):
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
 
         columns = ["birth_weight_exposure", "gestational_age_exposure"]
-        new_simulants = pd.DataFrame(columns=columns)
+        new_simulants = pd.DataFrame(columns=columns, index=pop_data.index)
 
         if pop_data.creation_time >= self.start_time:
             new_births = pop_data.user_data["new_births"]
-            new_births = new_births.reindex(index=pop_data.index)
+            new_births.index = pop_data.index
 
             # Create columns for state table
-            new_simulants = new_simulants.reindex(index=pop_data.index)
             new_simulants["birth_weight_exposure"] = new_births["birth_weight"]
             new_simulants["gestational_age_exposure"] = new_births["gestational_age"]
 

--- a/src/vivarium_gates_child_iv_iron/components/lbwsg.py
+++ b/src/vivarium_gates_child_iv_iron/components/lbwsg.py
@@ -21,6 +21,13 @@ class LBWSGLineList(LBWSGRisk):
     def __init__(self):
         super().__init__()
 
+    @property
+    def name(self)-> str:
+        return "line_list_low_birth_weight_and_short_gestation"
+
+    def __repr__(self):
+        return "LBWSGLineList()"
+
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         super().setup(builder)

--- a/src/vivarium_gates_child_iv_iron/components/lbwsg.py
+++ b/src/vivarium_gates_child_iv_iron/components/lbwsg.py
@@ -19,9 +19,6 @@ class LBWSGLineList(LBWSGRisk):
     """
     Component to initialize low birthweight and short gestation data for simulants based on existing line list data.
     """
-    def __init__(self):
-        super().__init__()
-
     @property
     def name(self)-> str:
         return "line_list_low_birth_weight_and_short_gestation"

--- a/src/vivarium_gates_child_iv_iron/components/lbwsg.py
+++ b/src/vivarium_gates_child_iv_iron/components/lbwsg.py
@@ -33,6 +33,7 @@ class LBWSGLineList(LBWSGRisk):
         super().setup(builder)
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        # todo: fix this like population component
         new_births = pop_data.user_data["new_births"]
         new_births = new_births.rename(columns={"birth_weight": "birth_weight_exposure",
                                                 "gestational_age": "gestational_age_exposure"

--- a/src/vivarium_gates_child_iv_iron/components/lbwsg.py
+++ b/src/vivarium_gates_child_iv_iron/components/lbwsg.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
+from vivarium.framework.time import get_time_stamp
 from vivarium_public_health.risks.implementations.low_birth_weight_and_short_gestation import LBWSGRisk
 
 
@@ -31,12 +32,20 @@ class LBWSGLineList(LBWSGRisk):
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder):
         super().setup(builder)
+        self.start_time = get_time_stamp(builder.configuration.time.start)
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
-        # todo: fix this like population component
-        new_births = pop_data.user_data["new_births"]
-        new_births = new_births.rename(columns={"birth_weight": "birth_weight_exposure",
-                                                "gestational_age": "gestational_age_exposure"
-                                                }
-                                       )
-        self.population_view.update(new_births)
+
+        columns = ["birth_weight_exposure", "gestational_age_exposure"]
+        new_simulants = pd.DataFrame(columns=columns)
+
+        if pop_data.creation_time >= self.start_time:
+            new_births = pop_data.user_data["new_births"]
+            new_births = new_births.reindex(index=pop_data.index)
+
+            # Create columns for state table
+            new_simulants = new_simulants.reindex(index=pop_data.index)
+            new_simulants["birth_weight_exposure"] = new_births["birth_weight"]
+            new_simulants["gestational_age_exposure"] = new_births["gestational_age"]
+
+        self.population_view.update(new_simulants)

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -7,24 +7,14 @@ This module contains a component for creating a base population from line list d
 
 """
 import glob
-from typing import Callable, Dict, List
 
-import numpy as np
 import pandas as pd
 from vivarium.framework.engine import Builder
-from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
-from vivarium.framework.randomness import RandomnessStream
 
-from vivarium_public_health import utilities
 from vivarium_public_health.population.base_population import BasePopulation, generate_population
-from vivarium_public_health.population.data_transformations import (
-    assign_demographic_proportions,
-    load_population_structure,
-    rescale_binned_proportions,
-    smooth_ages,
-)
 
+from vivarium_gates_child_iv_iron.constants.metadata import LOCATIONS
 
 class PopulationLineList(BasePopulation):
     """
@@ -36,8 +26,7 @@ class PopulationLineList(BasePopulation):
 
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
-        self.birth_records = self._get_birth_records()
-        self.fertility_data_directory = builder.fertility.fertility_input_data_path
+        self.location = self._get_location(builder)
 
     @property
     def name(self) -> str:
@@ -49,39 +38,23 @@ class PopulationLineList(BasePopulation):
         determined by the input data.
         """
 
-        # todo: check dtypes of data due to pd.read_hdf
-        new_births_index = pop_data.new_births
-        birth_records = self.birth_records
-        birth_records["age_start"] = self.config.age_start
-        birth_records["age_end"] = self.config.age_end
-        new_births = birth_records.iloc[new_births_index]
+        new_births = pop_data.user_data["new_births"]
+        new_births["alive"] = "alive"
+        new_births["location"] = self.location
+        new_births["entrance_time"] = pop_data.creation_time
+        new_births["exit_time"] = pd.NaT
+        new_births["location"] = self.location
 
-        creation_time = new_births.birth_date
-        #todo fix this >> age_start and how to get these since they arent in Simulant data
-        age_params = {
-            "age_start": new_births.age_start
-            "age_end": new_births.age_end,
-        }
+        self.population_view.update(new_births)
 
-        self.population_view.update(
-            generate_population(
-                simulant_ids=new_births_index,
-                creation_time=pop_data.creation_time,
-                step_size=pop_data.creation_window,  # Not sure what to do about this
-                age_params=age_params,
-                population_data=new_births,   # columns?
-                randomness_streams=self.randomness,
-                register_simulants=self.register_simulants,
-            )
-        )
+    def _get_location(self, builder: Builder) -> str:
+        location_mapper = {'sub-saharan_africa': 'Sub-Saharan Africa',
+                           'south_asia': 'South Asia',
+                           'lmics': 'LMICs'}
+        artifact_path = builder.configuration.input_data.artifact_path
 
-    def _get_birth_records(self) -> pd.DataFrame:
-        """
-        Method to load existing fertility data to use as birth records.
-        """
-        fertility_data_dir = self.fertility_data_directory
-        file_path = glob.glob(fertility_data_dir + 'south_asia*.hdf')[0]
-        # todo: fix path names to incorporate what draw and seed to use
-        birth_records = pd.read_hdf(file_path)
+        for key in location_mapper.keys():
+            if key in artifact_path:
+                location = location_mapper[key]
 
-        return birth_records
+                return location

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -1,0 +1,87 @@
+"""
+==========================
+Module for Base Population
+==========================
+
+This module contains a component for creating a base population from line list data.
+
+"""
+import glob
+from typing import Callable, Dict, List
+
+import numpy as np
+import pandas as pd
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.population import SimulantData
+from vivarium.framework.randomness import RandomnessStream
+
+from vivarium_public_health import utilities
+from vivarium_public_health.population.base_population import BasePopulation, generate_population
+from vivarium_public_health.population.data_transformations import (
+    assign_demographic_proportions,
+    load_population_structure,
+    rescale_binned_proportions,
+    smooth_ages,
+)
+
+
+class PopulationLineList(BasePopulation):
+    """
+    Component to produce and age simulants based on line list data.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
+        self.birth_records = self._get_birth_records()
+        self.fertility_data_directory = builder.fertility.fertility_input_data_path
+
+    @property
+    def name(self) -> str:
+        return "line_list_population"
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        """
+        Creates simulants based on their birth date from the line list data.  Their demographic characteristics are also
+        determined by the input data.
+        """
+
+        # todo: check dtypes of data due to pd.read_hdf
+        new_births_index = pop_data.new_births
+        birth_records = self.birth_records
+        birth_records["age_start"] = self.config.age_start
+        birth_records["age_end"] = self.config.age_end
+        new_births = birth_records.iloc[new_births_index]
+
+        creation_time = new_births.birth_date
+        #todo fix this >> age_start and how to get these since they arent in Simulant data
+        age_params = {
+            "age_start": new_births.age_start
+            "age_end": new_births.age_end,
+        }
+
+        self.population_view.update(
+            generate_population(
+                simulant_ids=new_births_index,
+                creation_time=pop_data.creation_time,
+                step_size=pop_data.creation_window,  # Not sure what to do about this
+                age_params=age_params,
+                population_data=new_births,   # columns?
+                randomness_streams=self.randomness,
+                register_simulants=self.register_simulants,
+            )
+        )
+
+    def _get_birth_records(self) -> pd.DataFrame:
+        """
+        Method to load existing fertility data to use as birth records.
+        """
+        fertility_data_dir = self.fertility_data_directory
+        file_path = glob.glob(fertility_data_dir + 'south_asia*.hdf')[0]
+        # todo: fix path names to incorporate what draw and seed to use
+        birth_records = pd.read_hdf(file_path)
+
+        return birth_records

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -42,15 +42,14 @@ class PopulationLineList(BasePopulation):
         determined by the input data.
         """
         columns = ["age", "sex", "alive", "location", "entrance_time", "exit_time"]
-        new_simulants = pd.DataFrame(columns=columns)
+        new_simulants = pd.DataFrame(columns=columns, index=pop_data.index)
 
         if pop_data.creation_time >= self.start_time:  # todo: is this logic right?
             new_births = pop_data.user_data["new_births"]
-            new_births = new_births.reindex(index=pop_data.index)
+            new_births.index = pop_data.index
 
             # Create columns for state table
-            new_simulants = new_simulants.reindex(index=pop_data.index)
-            new_simulants["age"] = 0
+            new_simulants["age"] = 0.0
             new_simulants["sex"] = new_births["sex"]
             # todo: make sure indexes work for sex
             new_simulants["alive"] = "alive"

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -51,7 +51,6 @@ class PopulationLineList(BasePopulation):
             # Create columns for state table
             new_simulants["age"] = 0.0
             new_simulants["sex"] = new_births["sex"]
-            # todo: make sure indexes work for sex
             new_simulants["alive"] = "alive"
             new_simulants["location"] = self.location
             new_simulants["entrance_time"] = pop_data.creation_time

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -16,8 +16,6 @@ from vivarium.framework.time import get_time_stamp
 
 from vivarium_public_health.population.base_population import BasePopulation
 
-from vivarium_gates_child_iv_iron.constants.metadata import LOCATIONS
-
 
 class PopulationLineList(BasePopulation):
     """
@@ -44,7 +42,7 @@ class PopulationLineList(BasePopulation):
         columns = ["age", "sex", "alive", "location", "entrance_time", "exit_time"]
         new_simulants = pd.DataFrame(columns=columns, index=pop_data.index)
 
-        if pop_data.creation_time >= self.start_time:  # todo: is this logic right?
+        if pop_data.creation_time >= self.start_time:
             new_births = pop_data.user_data["new_births"]
             new_births.index = pop_data.index
 

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -44,12 +44,12 @@ class PopulationLineList(BasePopulation):
         columns = ["age", "sex", "alive", "location", "entrance_time", "exit_time"]
         new_simulants = pd.DataFrame(columns=columns)
 
-        if pop_data.creation_time >= self.start_time:
+        if pop_data.creation_time >= self.start_time:  # todo: is this logic right?
             new_births = pop_data.user_data["new_births"]
             new_births = new_births.reindex(index=pop_data.index)
-            new_simulants = new_simulants.reindex(index=pop_data.index)
 
             # Create columns for state table
+            new_simulants = new_simulants.reindex(index=pop_data.index)
             new_simulants["age"] = 0
             new_simulants["sex"] = new_births["sex"]
             # todo: make sure indexes work for sex

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -32,6 +32,9 @@ class PopulationLineList(BasePopulation):
     def name(self) -> str:
         return "line_list_population"
 
+    def __repr__(self) -> str:
+        return "PopulationLineList()"
+
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         """
         Creates simulants based on their birth date from the line list data.  Their demographic characteristics are also

--- a/src/vivarium_gates_child_iv_iron/components/population.py
+++ b/src/vivarium_gates_child_iv_iron/components/population.py
@@ -9,20 +9,19 @@ This module contains a component for creating a base population from line list d
 import glob
 
 import pandas as pd
+
 from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
 
-from vivarium_public_health.population.base_population import BasePopulation, generate_population
+from vivarium_public_health.population.base_population import BasePopulation
 
 from vivarium_gates_child_iv_iron.constants.metadata import LOCATIONS
+
 
 class PopulationLineList(BasePopulation):
     """
     Component to produce and age simulants based on line list data.
     """
-
-    def __init__(self):
-        super().__init__()
 
     def setup(self, builder: Builder) -> None:
         super().setup(builder)
@@ -51,13 +50,4 @@ class PopulationLineList(BasePopulation):
         self.population_view.update(new_births)
 
     def _get_location(self, builder: Builder) -> str:
-        location_mapper = {'sub-saharan_africa': 'Sub-Saharan Africa',
-                           'south_asia': 'South Asia',
-                           'lmics': 'LMICs'}
-        artifact_path = builder.configuration.input_data.artifact_path
-
-        for key in location_mapper.keys():
-            if key in artifact_path:
-                location = location_mapper[key]
-
-                return location
+        return builder.data.load("population.location")

--- a/src/vivarium_gates_child_iv_iron/constants/paths.py
+++ b/src/vivarium_gates_child_iv_iron/constants/paths.py
@@ -9,4 +9,5 @@ ARTIFACT_ROOT = Path(f"/share/costeffectiveness/artifacts/{metadata.PROJECT_NAME
 MODEL_SPEC_DIR = BASE_DIR / 'model_specifications'
 RESULTS_ROOT = Path(f'/share/costeffectiveness/results/{metadata.PROJECT_NAME}/')
 
+FERTILITY_TEST_DATA_DIR = Path('/mnt/team/simulation_science/priv/engineering/scratch/vivarium_gates_child_iv_iron/child_data/south_asia.intervention.142.5.hdf')
 TEMPORARY_PAF_DIR = Path('/share/costeffectiveness/auxiliary_data/GBD_2019/01_original_data/population_attributable_fraction/risk_factor/lbwsg/data/')

--- a/src/vivarium_gates_child_iv_iron/constants/paths.py
+++ b/src/vivarium_gates_child_iv_iron/constants/paths.py
@@ -9,5 +9,4 @@ ARTIFACT_ROOT = Path(f"/share/costeffectiveness/artifacts/{metadata.PROJECT_NAME
 MODEL_SPEC_DIR = BASE_DIR / 'model_specifications'
 RESULTS_ROOT = Path(f'/share/costeffectiveness/results/{metadata.PROJECT_NAME}/')
 
-FERTILITY_TEST_DATA_DIR = Path('/mnt/team/simulation_science/priv/engineering/scratch/vivarium_gates_child_iv_iron/child_data/south_asia.intervention.142.5.hdf')
 TEMPORARY_PAF_DIR = Path('/share/costeffectiveness/auxiliary_data/GBD_2019/01_original_data/population_attributable_fraction/risk_factor/lbwsg/data/')

--- a/src/vivarium_gates_child_iv_iron/constants/results.py
+++ b/src/vivarium_gates_child_iv_iron/constants/results.py
@@ -18,7 +18,7 @@ RANDOM_SEED_COLUMN = 'random_seed'
 
 OUTPUT_INPUT_DRAW_COLUMN = 'input_data.input_draw_number'
 OUTPUT_RANDOM_SEED_COLUMN = 'randomness.random_seed'
-OUTPUT_SCENARIO_COLUMN = 'intervention'
+OUTPUT_SCENARIO_COLUMN = 'intervention.scenario'
 
 STANDARD_COLUMNS = {
     'total_population': TOTAL_POPULATION_COLUMN,

--- a/src/vivarium_gates_child_iv_iron/constants/results.py
+++ b/src/vivarium_gates_child_iv_iron/constants/results.py
@@ -18,7 +18,7 @@ RANDOM_SEED_COLUMN = 'random_seed'
 
 OUTPUT_INPUT_DRAW_COLUMN = 'input_data.input_draw_number'
 OUTPUT_RANDOM_SEED_COLUMN = 'randomness.random_seed'
-OUTPUT_SCENARIO_COLUMN = 'placeholder_branch_name.scenario'
+OUTPUT_SCENARIO_COLUMN = 'intervention'
 
 STANDARD_COLUMNS = {
     'total_population': TOTAL_POPULATION_COLUMN,

--- a/src/vivarium_gates_child_iv_iron/constants/results.py
+++ b/src/vivarium_gates_child_iv_iron/constants/results.py
@@ -100,7 +100,7 @@ NON_COUNT_TEMPLATES = [
 
 POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
-YEARS = tuple(range(2022, 2024))
+YEARS = tuple(range(2022, 2028))
 AGE_GROUPS = (
     'early_neonatal',
     'late_neonatal',

--- a/src/vivarium_gates_child_iv_iron/model_specifications/branches/scenarios.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/branches/scenarios.yaml
@@ -2,6 +2,10 @@ input_draw_count: 66
 random_seed_count: 10
 
 branches:
-# TODO change to name of intervention
-  - placeholder_branch_name:
-      scenario: ['baseline']
+  - intervention:
+      scenario: ['baseline',
+                 'oral_iron',
+                 'antenatal_iv_iron',
+                 'postpartum_iv_iron',
+                 'antenatal_and_postpartum_iv_iron'
+                ]

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -46,6 +46,7 @@ configuration:
     input_data:
         input_draw_number: 0
         artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_child_iv_iron/south_asia.hdf'
+        fertility_input_data_path: "/home/albrja/scratch/data/iv_iron_child/"
     interpolation:
         order: 0
         extrapolate: True
@@ -68,8 +69,6 @@ configuration:
         age_start: 0
         age_end: 5
         exit_age: 5
-    fertility:
-        input_data_path: '/mnt/team/simulation_science/priv/engineering/scratch/vivarium_gates_child_iv_iron/child_data/'
     moderate_protein_energy_malnutrition:
         threshold: ['cat2']
         mortality: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -60,7 +60,7 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2027
+            year: 2028
             month: 12
             day: 31
         step_size: .5 # Days

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -2,7 +2,6 @@
 components:
     vivarium_public_health:
         population:
-            - BasePopulation()
             - Mortality()
         disease:
             - SIS('diarrheal_diseases')
@@ -46,7 +45,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: '/home/albrja/scratch/data/iv_iron_child/'
+        artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_child_iv_iron/south_asia.hdf'
     interpolation:
         order: 0
         extrapolate: True
@@ -65,12 +64,12 @@ configuration:
             day: 31
         step_size: .5 # Days
     population:
-        population_size: 10_000
+        population_size: 0
         age_start: 0
         age_end: 5
         exit_age: 5
     fertility:
-        fertility_input_data_path: '/mnt/team/simulation_science/priv/engineering/scratch/vivarium_gates_child_iv_iron/child_data/'
+        input_data_path: '/mnt/team/simulation_science/priv/engineering/scratch/vivarium_gates_child_iv_iron/child_data/'
     moderate_protein_energy_malnutrition:
         threshold: ['cat2']
         mortality: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -38,7 +38,7 @@ components:
 
     vivarium_gates_child_iv_iron:
         components:
-            - FertilityFromOutputs()
+            - FertilityLineList()
             - ResultsStratifier()
             - BirthObserver()
 

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -46,7 +46,7 @@ configuration:
     input_data:
         input_draw_number: 0
         artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_child_iv_iron/south_asia.hdf'
-        fertility_input_data_path: "/home/albrja/scratch/data/iv_iron_child/"
+        fertility_input_data_path: "/ihme/costeffectiveness/results/vivarium_gates_iv_iron/v8.0_intervention_scenarios/south_asia/2022_05_18_13_14_26/child_data/scenario_postpartum_iv_iron_draw_990_seed_70.hdf"
     interpolation:
         order: 0
         extrapolate: True
@@ -60,8 +60,8 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2023
-            month: 12
+            year: 2022
+            month: 1
             day: 31
         step_size: .5 # Days
     population:
@@ -69,6 +69,8 @@ configuration:
         age_start: 0
         age_end: 5
         exit_age: 5
+    intervention:
+        scenario: 'baseline'
     moderate_protein_energy_malnutrition:
         threshold: ['cat2']
         mortality: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -4,7 +4,6 @@ components:
         population:
             - BasePopulation()
             - Mortality()
-            - FertilityCrudeBirthRate()
         disease:
             - SIS('diarrheal_diseases')
             - SIS_fixed_duration('measles', '10.0')
@@ -39,6 +38,7 @@ components:
 
     vivarium_gates_child_iv_iron:
         components:
+            - FertilityFromOutputs()
             - ResultsStratifier()
             - BirthObserver()
 
@@ -68,6 +68,8 @@ configuration:
         age_start: 0
         age_end: 5
         exit_age: 5
+    fertility:
+        fertility_input_data_path: '/mnt/team/simulation_science/priv/engineering/scratch/vivarium_gates_child_iv_iron/child_data/'
     moderate_protein_energy_malnutrition:
         threshold: ['cat2']
         mortality: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -46,7 +46,7 @@ components:
 configuration:
     input_data:
         input_draw_number: 0
-        artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_child_iv_iron/south_asia.hdf'
+        artifact_path: '/home/albrja/scratch/data/iv_iron_child/'
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -60,7 +60,7 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2023
+            year: 2027
             month: 12
             day: 31
         step_size: .5 # Days

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -46,7 +46,7 @@ configuration:
     input_data:
         input_draw_number: 0
         artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_child_iv_iron/south_asia.hdf'
-        fertility_input_data_path: "/ihme/costeffectiveness/results/vivarium_gates_iv_iron/v8.0_intervention_scenarios/south_asia/2022_05_18_13_14_26/child_data/scenario_postpartum_iv_iron_draw_990_seed_70.hdf"
+        fertility_input_data_path: "/ihme/costeffectiveness/results/vivarium_gates_iv_iron/v8.0_intervention_scenarios/south_asia/2022_05_18_13_14_26/child_data/"
     interpolation:
         order: 0
         extrapolate: True

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -21,7 +21,6 @@ components:
             - RiskEffect('risk_factor.child_stunting', 'cause.measles.incidence_rate')
             - RiskEffect('risk_factor.child_stunting', 'cause.lower_respiratory_infections.incidence_rate')
 
-            - LBWSGRisk()
             - LBWSGRiskEffect('cause.diarrheal_diseases.excess_mortality_rate')
             - LBWSGRiskEffect('cause.lower_respiratory_infections.excess_mortality_rate')
             - LBWSGRiskEffect('cause.affected_unmodeled.cause_specific_mortality_rate')
@@ -38,7 +37,9 @@ components:
 
     vivarium_gates_child_iv_iron:
         components:
+            - PopulationLineList()
             - FertilityLineList()
+            - LBWSGLineList()
             - ResultsStratifier()
             - BirthObserver()
 

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -60,8 +60,8 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2022
-            month: 1
+            year: 2023
+            month: 12
             day: 31
         step_size: .5 # Days
     population:


### PR DESCRIPTION
## Feature Line List Fertility.  Uses maternal model output data for simulation fertility inputs to produce the population.

### Description
Uses fertility line list data as the simulation population.  This allows the tracking of key data sources from the maternal model to the child model for the IV Iron project.
- *Category*: Implementatkon
- *JIRA issue*: [MIC-3076](https://jira.ihme.washington.edu/browse/MIC-3076)
- *Research reference*:  https://vivarium-research.readthedocs.io/en/latest/concept_models/vivarium_iv_iron/child_model/concept_model.html#id8

Added 3 new components:
    - A fertility component which loads line list data based on draw, seed, and intervention (intervention being what intervention takes place in the maternal model).  The fertility component determines when simulants are born (or created) in the simulation based on the birth dates.
    - A population component which is a subclass of the base population from Vivarium Public Health which initializes simulants from the line list data and creates necessary columns needed that are needed for the population manager.
    - A low birthweight and short gestation component which is also a subclass from VPH that updates the state table for birth weight and gestational age from the fertility line list data.

Added a key in the config file for fertility input data path location and updated the scenarios config file to include interventions that the women experience in the maternal model.  

### Verification and Testing
Ran an interactive simulation and verified simulants were being initialized at the correct time and the correct data was transferred to the state table for each individual.  Successfully  completed model runs.

