### PR TITLE
Feature/lri enn data

### DIFF
--- a/src/vivarium_gates_child_iv_iron/constants/data_keys.py
+++ b/src/vivarium_gates_child_iv_iron/constants/data_keys.py
@@ -164,6 +164,7 @@ class __SevereProteinEnergyMalnutrition(NamedTuple):
     def log_name(self):
         return 'severe protein energy malnutrition'
 
+
 SEVERE_PEM = __SevereProteinEnergyMalnutrition()
 
 
@@ -265,6 +266,7 @@ class __AffectedUnmodeledCauses(NamedTuple):
     NEONATAL_JAUNDICE_CSMR: TargetString = TargetString('cause.hemolytic_disease_and_other_neonatal_jaundice.cause_specific_mortality_rate')
     OTHER_NEONATAL_DISORDERS_CSMR: TargetString = TargetString('cause.other_neonatal_disorders.cause_specific_mortality_rate')
     SIDS_CSMR: TargetString = TargetString('cause.sudden_infant_death_syndrome.cause_specific_mortality_rate')
+    NEONATAL_LRI_CSMR: TargetString = TargetString('cause.neonatal_lower_respiratory_infections.cause_specific_mortality_rate')
 
     # Useful keys not for the artifact - distinguished by not using the colon type declaration
 

--- a/src/vivarium_gates_child_iv_iron/constants/metadata.py
+++ b/src/vivarium_gates_child_iv_iron/constants/metadata.py
@@ -65,3 +65,5 @@ class __AgeGroup(NamedTuple):
 
 
 AGE_GROUP = __AgeGroup()
+
+NEONATAL_END_AGE = 0.076712

--- a/src/vivarium_gates_child_iv_iron/data/loader.py
+++ b/src/vivarium_gates_child_iv_iron/data/loader.py
@@ -825,7 +825,7 @@ def load_neonatal_lri_csmr(key: str, location: str) -> pd.DataFrame:
         raise ValueError(f"Unrecognized key {key}")
 
     data = load_standard_data(data_keys.LRI.CSMR, location)
-    data.loc[data.index.get_level_values('age_start') >= 0.076712, :] = 0
+    data.loc[data.index.get_level_values('age_start') >= metadata.NEONATAL_END_AGE, :] = 0
     return data
 
 
@@ -834,5 +834,5 @@ def load_lri_csmr(key: str, location: str) -> pd.DataFrame:
         raise ValueError(f"Unrecognized key {key}")
 
     data = load_standard_data(data_keys.LRI.CSMR, location)
-    data.loc[data.index.get_level_values('age_start') < 0.076712, :] = 0
+    data.loc[data.index.get_level_values('age_start') < metadata.NEONATAL_END_AGE, :] = 0
     return data

--- a/src/vivarium_gates_child_iv_iron/data/loader.py
+++ b/src/vivarium_gates_child_iv_iron/data/loader.py
@@ -80,7 +80,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.LRI.REMISSION_RATE: load_remission_rate_from_duration,
         data_keys.LRI.DISABILITY_WEIGHT: load_standard_data,
         data_keys.LRI.EMR: load_emr_from_csmr_and_prevalence,
-        data_keys.LRI.CSMR: load_standard_data,
+        data_keys.LRI.CSMR: load_lri_csmr,
         data_keys.LRI.RESTRICTIONS: load_metadata,
 
         data_keys.WASTING.DISTRIBUTION: load_metadata,
@@ -89,6 +89,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.WASTING.EXPOSURE: load_standard_data,
         data_keys.WASTING.RELATIVE_RISK: load_standard_data,
         data_keys.WASTING.PAF: load_categorical_paf,
+
         data_keys.STUNTING.DISTRIBUTION: load_metadata,
         data_keys.STUNTING.ALT_DISTRIBUTION: load_metadata,
         data_keys.STUNTING.CATEGORIES: load_metadata,
@@ -122,6 +123,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_JAUNDICE_CSMR: load_standard_data,
         data_keys.AFFECTED_UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_CSMR: load_standard_data,
         data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_CSMR: load_sids_csmr,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_LRI_CSMR: load_neonatal_lri_csmr,
 
         data_keys.IFA_SUPPLEMENTATION.DISTRIBUTION: load_intervention_distribution,
         data_keys.IFA_SUPPLEMENTATION.CATEGORIES: load_intervention_categories,
@@ -302,7 +304,6 @@ def load_prevalence_from_incidence_and_duration(key: str, location: str) -> pd.D
     birth_prevalence = data_values.BIRTH_PREVALENCE_OF_ZERO
     enn_prevalence = prevalence.query("age_start == 0")
     enn_prevalence = (birth_prevalence + enn_prevalence) / 2
-
     all_other_prevalence = prevalence.query("age_start != 0.0")
 
     prevalence = pd.concat([enn_prevalence, all_other_prevalence]).sort_index()
@@ -817,3 +818,21 @@ def load_maternal_bmi_anemia_excess_shift(key: str, location: str) -> pd.DataFra
         .sort_index()
     )
     return excess_shift
+
+
+def load_neonatal_lri_csmr(key: str, location: str) -> pd.DataFrame:
+    if key != data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_LRI_CSMR:
+        raise ValueError(f"Unrecognized key {key}")
+
+    data = load_standard_data(data_keys.LRI.CSMR, location)
+    data.loc[data.index.get_level_values('age_start') >= 0.076712, :] = 0
+    return data
+
+
+def load_lri_csmr(key: str, location: str) -> pd.DataFrame:
+    if key != data_keys.LRI.CSMR:
+        raise ValueError(f"Unrecognized key {key}")
+
+    data = load_standard_data(data_keys.LRI.CSMR, location)
+    data.loc[data.index.get_level_values('age_start') < 0.076712, :] = 0
+    return data

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -92,6 +92,7 @@ configuration:
         - "hemolytic_disease_and_other_neonatal_jaundice"
         - "other_neonatal_disorders"
         - "sudden_infant_death_syndrome"
+        - "neonatal_lower_respiratory_infections"
 
     moderate_protein_energy_malnutrition:
         threshold: ['cat2']


### PR DESCRIPTION
## Feature/LRI Neonatal Data Artifact

### Description
Updated data artifact to incorporate data for early and late neonatal LRI cause custom age split.
- *Category*: Data artifact
- *JIRA issue*: [MIC-3117](https://jira.ihme.washington.edu/browse/MIC-XYZ)
- *Research reference*: https://github.com/ihmeuw/vivarium_research/pull/883/files

-Updated data keys for LRI cause split to have post neonatal LRI and neonatal LRI for unmodeled causes.
-Updated loader functions for new data keys and split CSMR loading for custom age split.

### Verification and Testing
Successfully wrote artifacts for both locations and data looks as expected.

