### PR TITLE
Feature/diarrhea split

### DIFF
--- a/src/vivarium_gates_child_iv_iron/components/__init__.py
+++ b/src/vivarium_gates_child_iv_iron/components/__init__.py
@@ -1,3 +1,4 @@
+from vivarium_gates_child_iv_iron.components.causes import SIS_with_birth_prevalence
 from vivarium_gates_child_iv_iron.components.fertility import FertilityLineList
 from vivarium_gates_child_iv_iron.components.lbwsg import LBWSGLineList
 from vivarium_gates_child_iv_iron.components.maternal_characteristics import (

--- a/src/vivarium_gates_child_iv_iron/components/causes.py
+++ b/src/vivarium_gates_child_iv_iron/components/causes.py
@@ -9,7 +9,7 @@ from vivarium_public_health.disease import (
 )
 
 
-def sis_neonatal_split(cause: str) -> DiseaseModel:
+def SIS_with_birth_prevalence(cause: str) -> DiseaseModel:
     with_condition_data_functions = {
         "birth_prevalence": lambda cause, builder: builder.data.load(
             f"cause.{cause}.birth_prevalence"

--- a/src/vivarium_gates_child_iv_iron/components/causes.py
+++ b/src/vivarium_gates_child_iv_iron/components/causes.py
@@ -1,0 +1,27 @@
+"""
+Component to include birth prevalence in SIS model.
+"""
+
+from vivarium_public_health.disease import (
+    DiseaseModel,
+    DiseaseState,
+    SusceptibleState,
+)
+
+
+def sis_neonatal_split(cause: str) -> DiseaseModel:
+    with_condition_data_functions = {
+        "birth_prevalence": lambda cause, builder: builder.data.load(
+            f"cause.{cause}.birth_prevalence"
+        )
+    }
+
+    healthy = SusceptibleState(cause)
+    infected = DiseaseState(cause, get_data_functions=with_condition_data_functions)
+
+    healthy.allow_self_transitions()
+    healthy.add_transition(infected, source_data_type="rate")
+    infected.allow_self_transitions()
+    infected.add_transition(healthy, source_data_type="rate")
+
+    return DiseaseModel(cause, states=[healthy, infected])

--- a/src/vivarium_gates_child_iv_iron/constants/data_keys.py
+++ b/src/vivarium_gates_child_iv_iron/constants/data_keys.py
@@ -48,6 +48,7 @@ class __DiarrhealDiseases(NamedTuple):
     EMR: TargetString = TargetString('cause.diarrheal_diseases.excess_mortality_rate')
     CSMR: TargetString = TargetString('cause.diarrheal_diseases.cause_specific_mortality_rate')
     RESTRICTIONS: TargetString = TargetString('cause.diarrheal_diseases.restrictions')
+    BIRTH_PREVALENCE: TargetString = TargetString('cause.diarrheal_diseases.birth_prevalence')
 
     # Useful keys not for the artifact - distinguished by not using the colon type declaration
 
@@ -267,6 +268,7 @@ class __AffectedUnmodeledCauses(NamedTuple):
     OTHER_NEONATAL_DISORDERS_CSMR: TargetString = TargetString('cause.other_neonatal_disorders.cause_specific_mortality_rate')
     SIDS_CSMR: TargetString = TargetString('cause.sudden_infant_death_syndrome.cause_specific_mortality_rate')
     NEONATAL_LRI_CSMR: TargetString = TargetString('cause.neonatal_lower_respiratory_infections.cause_specific_mortality_rate')
+    NEONATAL_DIARRHEAL_DISEASES_CSMR: TargetString = TargetString('cause.neonatal_diarrheal_diseases.cause_specific_mortality_rate')
 
     # Useful keys not for the artifact - distinguished by not using the colon type declaration
 

--- a/src/vivarium_gates_child_iv_iron/data/loader.py
+++ b/src/vivarium_gates_child_iv_iron/data/loader.py
@@ -871,7 +871,7 @@ def load_diarrhea_birth_prevalence(key: str, location: str) -> pd.DataFrame:
     if key != data_keys.DIARRHEA.BIRTH_PREVALENCE:
         raise ValueError(f"Unrecognized key {key}")
 
-    prevalence = get_data(data_keys.DIARRHEA.BIRTH_PREVALENCE, location)
+    prevalence = get_data(data_keys.DIARRHEA.PREVALENCE, location)
     post_neonatal = prevalence.loc[
         (prevalence.index.get_level_values("age_start") >= metadata.NEONATAL_END_AGE)
         & (prevalence.index.get_level_values("age_start") < 1)

--- a/src/vivarium_gates_child_iv_iron/data/loader.py
+++ b/src/vivarium_gates_child_iv_iron/data/loader.py
@@ -64,7 +64,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.DIARRHEA.REMISSION_RATE: load_remission_rate_from_duration,
         data_keys.DIARRHEA.DISABILITY_WEIGHT: load_standard_data,
         data_keys.DIARRHEA.EMR: load_emr_from_csmr_and_prevalence,
-        data_keys.DIARRHEA.CSMR: load_standard_data,
+        data_keys.DIARRHEA.CSMR: load_diarrhea_csmr,
         data_keys.DIARRHEA.RESTRICTIONS: load_metadata,
 
         data_keys.MEASLES.PREVALENCE: load_standard_data,
@@ -307,6 +307,8 @@ def load_prevalence_from_incidence_and_duration(key: str, location: str) -> pd.D
     all_other_prevalence = prevalence.query("age_start != 0.0")
 
     prevalence = pd.concat([enn_prevalence, all_other_prevalence]).sort_index()
+
+    #todo: adjust prevalence for neonatal age groups to match post-neonatal group
 
     return prevalence
 
@@ -834,5 +836,14 @@ def load_lri_csmr(key: str, location: str) -> pd.DataFrame:
         raise ValueError(f"Unrecognized key {key}")
 
     data = load_standard_data(data_keys.LRI.CSMR, location)
+    data.loc[data.index.get_level_values('age_start') < metadata.NEONATAL_END_AGE, :] = 0
+    return data
+
+
+def load_diarrhea_csmr(key: str, location: str) -> pd.DataFrame:
+    if key != data_keys.DIARRHEA.CSMR:
+        raise ValueError(f"Unrecognized key {key}")
+
+    data = load_standard_data(data_keys.DIARRHEA.CSMR, location)
     data.loc[data.index.get_level_values('age_start') < metadata.NEONATAL_END_AGE, :] = 0
     return data

--- a/src/vivarium_gates_child_iv_iron/data/loader.py
+++ b/src/vivarium_gates_child_iv_iron/data/loader.py
@@ -66,6 +66,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.DIARRHEA.EMR: load_emr_from_csmr_and_prevalence,
         data_keys.DIARRHEA.CSMR: load_diarrhea_csmr,
         data_keys.DIARRHEA.RESTRICTIONS: load_metadata,
+        data_keys.DIARRHEA.BIRTH_PREVALENCE: load_diarrhea_birth_prevalence,
 
         data_keys.MEASLES.PREVALENCE: load_standard_data,
         data_keys.MEASLES.INCIDENCE_RATE: load_standard_data,
@@ -124,6 +125,7 @@ def get_data(lookup_key: str, location: str) -> pd.DataFrame:
         data_keys.AFFECTED_UNMODELED_CAUSES.OTHER_NEONATAL_DISORDERS_CSMR: load_standard_data,
         data_keys.AFFECTED_UNMODELED_CAUSES.SIDS_CSMR: load_sids_csmr,
         data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_LRI_CSMR: load_neonatal_lri_csmr,
+        data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_DIARRHEAL_DISEASES_CSMR: load_neonatal_diarrhea_csmr,
 
         data_keys.IFA_SUPPLEMENTATION.DISTRIBUTION: load_intervention_distribution,
         data_keys.IFA_SUPPLEMENTATION.CATEGORIES: load_intervention_categories,
@@ -308,8 +310,9 @@ def load_prevalence_from_incidence_and_duration(key: str, location: str) -> pd.D
 
     prevalence = pd.concat([enn_prevalence, all_other_prevalence]).sort_index()
 
-    #todo: adjust prevalence for neonatal age groups to match post-neonatal group
-
+    # If cause is diarrhea, set early and late neonatal groups prevalence to that of post-neonatal age group
+    if key == data_keys.DIARRHEA.PREVALENCE:
+        prevalence = utilities.scrub_neonatal_age_groups(prevalence)
     return prevalence
 
 
@@ -324,6 +327,9 @@ def load_remission_rate_from_duration(key: str, location: str) -> pd.DataFrame:
     step_size = 0.5 / 365  # years
     duration = get_data(cause.DURATION, location)
     remission_rate = (-1 / step_size) * np.log(1 - step_size / duration)
+
+    if key == data_keys.DIARRHEA.REMISSION_RATE:
+        remission_rate.loc[remission_rate.index.get_level_values('age_start') < metadata.NEONATAL_END_AGE, :] = 0
     return remission_rate
 
 
@@ -340,6 +346,9 @@ def load_emr_from_csmr_and_prevalence(key: str, location: str) -> pd.DataFrame:
     prevalence = get_data(cause.PREVALENCE, location)
     data = (csmr / prevalence).fillna(0)
     data = data.replace([np.inf, -np.inf], 0)
+
+    if key == data_keys.DIARRHEA.EMR:
+        data.loc[data.index.get_level_values('age_start') < metadata.NEONATAL_END_AGE, :] = 0
     return data
 
 
@@ -846,4 +855,27 @@ def load_diarrhea_csmr(key: str, location: str) -> pd.DataFrame:
 
     data = load_standard_data(data_keys.DIARRHEA.CSMR, location)
     data.loc[data.index.get_level_values('age_start') < metadata.NEONATAL_END_AGE, :] = 0
+    return data
+
+
+def load_neonatal_diarrhea_csmr(key: str, location: str) -> pd.DataFrame:
+    if key != data_keys.AFFECTED_UNMODELED_CAUSES.NEONATAL_DIARRHEAL_DISEASES_CSMR:
+        raise ValueError(f"Unrecognized key {key}")
+
+    data = load_standard_data(data_keys.DIARRHEA.CSMR, location)
+    data.loc[data.index.get_level_values('age_start') >= metadata.NEONATAL_END_AGE, :] = 0
+    return data
+
+
+def load_diarrhea_birth_prevalence(key: str, location: str) -> pd.DataFrame:
+    if key != data_keys.DIARRHEA.BIRTH_PREVALENCE:
+        raise ValueError(f"Unrecognized key {key}")
+
+    prevalence = get_data(data_keys.DIARRHEA.BIRTH_PREVALENCE, location)
+    post_neonatal = prevalence.loc[
+        (prevalence.index.get_level_values("age_start") >= metadata.NEONATAL_END_AGE)
+        & (prevalence.index.get_level_values("age_start") < 1)
+        ]
+    data = post_neonatal.droplevel(['age_start', 'age_end'])
+
     return data

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -93,6 +93,7 @@ configuration:
         - "other_neonatal_disorders"
         - "sudden_infant_death_syndrome"
         - "neonatal_lower_respiratory_infections"
+        - "neonatal_diarrheal_diseases"
 
     moderate_protein_energy_malnutrition:
         threshold: ['cat2']

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -54,7 +54,7 @@ configuration:
     input_data:
         input_draw_number: 0
         artifact_path: '/ihme/costeffectiveness/artifacts/vivarium_gates_child_iv_iron/south_asia.hdf'
-        fertility_input_data_path: "/mnt/share/costeffectiveness/results/vivarium_gates_iv_iron/v8.0_intervention_scenarios/south_asia/2022_06_07_11_48_50/child_data/"
+        fertility_input_data_path: '/ihme/costeffectiveness/results/vivarium_gates_iv_iron/v8.2_child_output_only/south_asia/2022_06_16_12_36_52/child_data/'
     interpolation:
         order: 0
         extrapolate: True
@@ -64,13 +64,13 @@ configuration:
         random_seed: 0
     time:
         start:
-            year: 2022
+            year: 2024
             month: 1
             day: 1
         end:
-            year: 2027
-            month: 12
-            day: 31
+            year: 2041
+            month: 1
+            day: 1
         step_size: .5 # Days
     population:
         population_size: 0

--- a/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
+++ b/src/vivarium_gates_child_iv_iron/model_specifications/iv_iron_child.yaml
@@ -4,7 +4,6 @@ components:
         population:
             - Mortality()
         disease:
-            - SIS('diarrheal_diseases')
             - SIS_fixed_duration('measles', '10.0')
             - SIS('lower_respiratory_infections')
             - RiskAttributableDisease('cause.moderate_protein_energy_malnutrition', 'risk_factor.child_wasting')
@@ -49,6 +48,7 @@ components:
             - AdditiveRiskEffect('risk_factor.iv_iron', 'risk_factor.birth_weight.birth_exposure')
             - AdditiveRiskEffect('risk_factor.maternal_bmi_anemia', 'risk_factor.birth_weight.birth_exposure')
             - BirthWeightShiftEffect()
+            - SIS_with_birth_prevalence('diarrheal_diseases')
 
 configuration:
     input_data:


### PR DESCRIPTION
## Feature/Diarrheal Diseases Neonatal Split

### Description
Implemented cause split for diarrheal diseases to split out neonatal age groups so simulants are initialized with post neonatal prevalence, do not transition, and there is no disability.
- *Category*: Data artifact/implementation
- *JIRA issue*: [MIC-3213](https://jira.ihme.washington.edu/browse/MIC-3213)
- *Research reference*: Wating on documentation

-Updated prevalence, EMR, remission rate and CSMR for diarrheal diseases. 
-Added birth prevalence data key for diarrheal diseases
-Created causes module that has custom SIS model for diarrheal diseases.
-Updated config file for new fertility data path and to implement refactoring of SIS model for diarrheal diseases.

### Verification and Testing
Successfully wrote artifacts for both super regions and data has been updated as expected.

