### PR TITLE
Update pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     install_requirements = [
         'vivarium==1.1.0',
         'vivarium_public_health==0.10.24',
-        'vivarium_cluster_tools==1.3.4',
+        'vivarium_cluster_tools==1.3.8',
         'click',
         'gbd_mapping==3.0.6',
         'jinja2',


### PR DESCRIPTION
## Update VCT pin

### Description
- *Category*:other/misc
- *JIRA issue*: [MIC-4051](https://jira.ihme.washington.edu/browse/MIC-4051)


Updates pin for vivarium_cluster_tools to 1.3.8 from 1.3.4

### Verification and Testing
This appears to be running ok in a model run.
