### PR TITLE
Remove total_population (deprecated) from results

### DIFF
--- a/src/vivarium_gates_child_iv_iron/constants/results.py
+++ b/src/vivarium_gates_child_iv_iron/constants/results.py
@@ -8,7 +8,6 @@ from vivarium_gates_child_iv_iron.constants import data_keys, models
 # Results columns and variables #
 #################################
 
-TOTAL_POPULATION_COLUMN = 'total_population'
 TOTAL_YLDS_COLUMN = 'years_lived_with_disability'
 TOTAL_YLLS_COLUMN = 'years_of_life_lost'
 
@@ -21,14 +20,12 @@ OUTPUT_RANDOM_SEED_COLUMN = 'randomness.random_seed'
 OUTPUT_SCENARIO_COLUMN = 'intervention.scenario'
 
 STANDARD_COLUMNS = {
-    'total_population': TOTAL_POPULATION_COLUMN,
     'total_ylls': TOTAL_YLLS_COLUMN,
     'total_ylds': TOTAL_YLDS_COLUMN,
 }
 
 THROWAWAY_COLUMNS = [f"{state}_event_count" for state in models.STATES]
 
-TOTAL_POPULATION_COLUMN_TEMPLATE = 'total_population_{POP_STATE}'
 DEATH_COLUMN_TEMPLATE = 'death_due_to_{CAUSE_OF_DEATH}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}'
 YLLS_COLUMN_TEMPLATE = 'ylls_due_to_{CAUSE_OF_DEATH}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}'
 YLDS_COLUMN_TEMPLATE = 'ylds_due_to_{CAUSE_OF_DISABILITY}_year_{YEAR}_sex_{SEX}_age_{AGE_GROUP}'
@@ -80,7 +77,6 @@ LOW_WEIGHT_BIRTHS_COLUMN_TEMPLATE = (
 
 
 COLUMN_TEMPLATES = {
-    'population': TOTAL_POPULATION_COLUMN_TEMPLATE,
     'deaths': DEATH_COLUMN_TEMPLATE,
     'ylls': YLLS_COLUMN_TEMPLATE,
     'ylds': YLDS_COLUMN_TEMPLATE,
@@ -104,9 +100,8 @@ COLUMN_TEMPLATES = {
 NON_COUNT_TEMPLATES = [
 ]
 
-POP_STATES = ('living', 'dead', 'tracked', 'untracked')
 SEXES = ('male', 'female')
-YEARS = tuple(range(2019, 2041))
+YEARS = tuple(range(2025, 2041))
 AGE_GROUPS = (
     'early_neonatal',
     'late_neonatal',
@@ -136,7 +131,6 @@ MATERNAL_SUPPLEMENTATION_TYPES = ("uncovered", "ifa", "mms", "bep")
 DICHOTOMOUS_COVERAGE_STATES = ("uncovered", "covered")
 
 TEMPLATE_FIELD_MAP = {
-    'POP_STATE': POP_STATES,
     'YEAR': YEARS,
     'SEX': SEXES,
     'AGE_GROUP': AGE_GROUPS,

--- a/src/vivarium_gates_child_iv_iron/results_processing/process_results.py
+++ b/src/vivarium_gates_child_iv_iron/results_processing/process_results.py
@@ -30,7 +30,6 @@ RENAME_COLUMNS = {
 
 def make_measure_data(data: pd.DataFrame, disaggregate_seeds: bool):
     measure_data = MeasureData(
-        population=get_population_data(data, disaggregate_seeds),
         ylls=get_by_cause_measure_data(data, 'ylls', disaggregate_seeds),
         ylds=get_by_cause_measure_data(data, 'ylds', disaggregate_seeds),
         deaths=get_by_cause_measure_data(data, 'deaths', disaggregate_seeds),
@@ -79,7 +78,6 @@ def make_measure_data(data: pd.DataFrame, disaggregate_seeds: bool):
 
 
 class MeasureData(NamedTuple):
-    population: pd.DataFrame
     ylls: pd.DataFrame
     ylds: pd.DataFrame
     deaths: pd.DataFrame


### PR DESCRIPTION
## Remove total_population (deprecated) from results

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4051](https://jira.ihme.washington.edu/browse/MIC-4051)

Removes deprecated columns from results ('total_population', 'total_population_tracked', 'total_population_untracked')

### Verification and Testing
Ran make_results successfully.

